### PR TITLE
Disable-ci-coding-style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       - name: "Install Composer dependencies"
         uses: "ramsey/composer-install@v2"
 
-      - name: "Check coding style"
-        run: composer cs
+      # - name: "Check coding style"
+      #   run: composer cs
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because it is not in sync with SimplePie code at all and make all tests fail
