### PR TITLE
PHPDoc fix some types for namespace

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -193,7 +193,7 @@ class Item implements RegistryAware
      * MD5 hash based on the permalink, title and content.
      *
      * @since Beta 2
-     * @param boolean $hash Should we force using a hash instead of the supplied ID?
+     * @param bool $hash Should we force using a hash instead of the supplied ID?
      * @param string|false $fn User-supplied function to generate an hash
      * @return string|null
      */
@@ -270,7 +270,7 @@ class Item implements RegistryAware
      * `<itunes:subtitle>`
      *
      * @since 0.8
-     * @param boolean $description_only Should we avoid falling back to the content?
+     * @param bool $description_only Should we avoid falling back to the content?
      * @return string|null
      */
     public function get_description(bool $description_only = false)
@@ -320,7 +320,7 @@ class Item implements RegistryAware
      * Uses `<atom:content>` or `<content:encoded>` (RSS 1.0 Content Module)
      *
      * @since 1.0
-     * @param boolean $content_only Should we avoid falling back to the description?
+     * @param bool $content_only Should we avoid falling back to the description?
      * @return string|null
      */
     public function get_content(bool $content_only = false)

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -283,7 +283,7 @@ class Misc
      * @param string $data Raw data in $input encoding
      * @param string $input Encoding of $data
      * @param string $output Encoding you want
-     * @return string|boolean False if we can't convert it
+     * @return string|bool False if we can't convert it
      */
     public static function change_encoding(string $data, string $input, string $output)
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -264,7 +264,7 @@ class Parser implements RegistryAware
     }
 
     /**
-     * @param XMLParser|resource|null $parser
+     * @param XMLParser|\resource|null $parser
      * @param array<string, string> $attributes
      * @return void
      */
@@ -321,7 +321,7 @@ class Parser implements RegistryAware
     }
 
     /**
-     * @param XMLParser|resource|null $parser
+     * @param XMLParser|\resource|null $parser
      * @return void
      */
     public function cdata($parser, string $cdata)
@@ -334,7 +334,7 @@ class Parser implements RegistryAware
     }
 
     /**
-     * @param XMLParser|resource|null $parser
+     * @param XMLParser|\resource|null $parser
      * @return void
      */
     public function tag_close($parser, string $tag)


### PR DESCRIPTION
To help PHPStan, otherwise could have been in the SimplePie namespace:
* use `bool` instead of `boolean`
* escape `\resource`