### PR TITLE
PHPDoc avoid aliases for scalar types

### DIFF
--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -475,7 +475,7 @@ class Parser
      * Prepare headers (take care of proxies headers)
      *
      * @param string  $headers Raw headers
-     * @param integer $count   Redirection count. Default to 1.
+     * @param int $count   Redirection count. Default to 1.
      *
      * @return string
      */

--- a/src/Item.php
+++ b/src/Item.php
@@ -175,7 +175,7 @@ class Item implements RegistryAware
      * MD5 hash based on the permalink, title and content.
      *
      * @since Beta 2
-     * @param boolean $hash Should we force using a hash instead of the supplied ID?
+     * @param bool $hash Should we force using a hash instead of the supplied ID?
      * @param string|false $fn User-supplied function to generate an hash
      * @return string|null
      */
@@ -252,7 +252,7 @@ class Item implements RegistryAware
      * `<itunes:subtitle>`
      *
      * @since 0.8
-     * @param boolean $description_only Should we avoid falling back to the content?
+     * @param bool $description_only Should we avoid falling back to the content?
      * @return string|null
      */
     public function get_description(bool $description_only = false)
@@ -302,7 +302,7 @@ class Item implements RegistryAware
      * Uses `<atom:content>` or `<content:encoded>` (RSS 1.0 Content Module)
      *
      * @since 1.0
-     * @param boolean $content_only Should we avoid falling back to the description?
+     * @param bool $content_only Should we avoid falling back to the description?
      * @return string|null
      */
     public function get_content(bool $content_only = false)

--- a/src/Misc.php
+++ b/src/Misc.php
@@ -283,7 +283,7 @@ class Misc
      * @param string $data Raw data in $input encoding
      * @param string $input Encoding of $data
      * @param string $output Encoding you want
-     * @return string|boolean False if we can't convert it
+     * @return string|bool False if we can't convert it
      */
     public static function change_encoding(string $data, string $input, string $output)
     {


### PR DESCRIPTION
https://php.net/language.types.declarations
Also helps PHPStan, which otherwise makes another lookup as it might be in the SimplePie namespace, and which fails in some cases.

Upstream PR: https://github.com/simplepie/simplepie/pull/868