### PR TITLE
Fix PHPStan 1.12.2

### DIFF
--- a/src/IRI.php
+++ b/src/IRI.php
@@ -301,12 +301,10 @@ class IRI
             if ($match[1] === '') {
                 $match['scheme'] = null;
             }
-            if (!isset($match[3]) || $match[3] === '') {
+            if ($match[3] === '') {
                 $match['authority'] = null;
             }
-            if (!isset($match[5])) {
-                $match['path'] = '';
-            }
+            $match['path'] = '';
             if (!isset($match[6]) || $match[6] === '') {
                 $match['query'] = null;
             }


### PR DESCRIPTION
CI breaks because upstream does not pin `composer.lock`...

```
------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/IRI.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  :304   Offset 3 on array{0: string, 1: '', scheme: null, 2: string, 3: string, authority: string, 4: string, path: string, ...}|array{0: string, 1: non-empty-string, scheme: string, 2: string, 3: string, authority: string, 4: string, path: string, ...} in isset()
         always exists and is not nullable.
  :307   Offset 5 on array{0: string, 1: '', scheme: null, 2: string, 3: string, authority: string|null, 4: string, path: string, ...}|array{0: string, 1: non-empty-string, scheme: string, 2: string, 3: string, authority: string|null, 4: string, path: string, ...}
         in isset() always exists and is not nullable.
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```