### PR TITLE
Fix CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19 || ^3.8",
         "mf2/mf2": "^0.5.0",
-        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan": "~1.11.11",
         "phpunit/phpunit": "^8 || ^9 || ^10",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",


### PR DESCRIPTION
Due to SimplePie not pinning `composer.lock`, CI tests are randomly failing with updates of test tools

```
------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/IRI.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  :304   Offset 3 on array{0: string, 1: '', scheme: null, 2: string, 3: string, authority: string, 4: string, path: string, ...}|array{0: string, 1: non-empty-string, scheme: string, 2: string, 3: string, authority: string, 4: string, path: string, ...} in isset()
         always exists and is not nullable.
  :307   Offset 5 on array{0: string, 1: '', scheme: null, 2: string, 3: string, authority: string|null, 4: string, path: string, ...}|array{0: string, 1: non-empty-string, scheme: string, 2: string, 3: string, authority: string|null, 4: string, path: string, ...}
         in isset() always exists and is not nullable.
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
