### PR TITLE
PHP 8.4 | Fix implicitly nullable parameters

### DIFF
--- a/src/IRI.php
+++ b/src/IRI.php
@@ -203,9 +203,9 @@ class IRI
     /**
      * Create a new IRI object, from a specified string
      *
-     * @param string $iri
+     * @param string|null $iri
      */
-    public function __construct(string $iri = null)
+    public function __construct(?string $iri = null)
     {
         $this->set_iri($iri);
     }

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -148,7 +148,7 @@ class Sanitize implements RegistryAware
      * @param class-string<Cache> $cache_class
      * @return void
      */
-    public function pass_cache_data(bool $enable_cache = true, string $cache_location = './cache', $cache_name_function = 'md5', string $cache_class = Cache::class, DataCache $cache = null)
+    public function pass_cache_data(bool $enable_cache = true, string $cache_location = './cache', $cache_name_function = 'md5', string $cache_class = Cache::class, ?DataCache $cache = null)
     {
         $this->enable_cache = $enable_cache;
 


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameter with a `null` default value, which are not explicitly declared as nullable.

Includes updating the documentation to match.

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

https://github.com/simplepie/simplepie/pull/880