### PR TITLE
Negotiate  cache_expiration_time

### DIFF
--- a/src/Cache/BaseDataCache.php
+++ b/src/Cache/BaseDataCache.php
@@ -90,6 +90,8 @@ final class BaseDataCache implements DataCache
     {
         if ($ttl === null) {
             $ttl = 3600;
+        } elseif ($ttl <= 0) {
+            return $this->delete_data($key); // FreshRSS
         }
 
         // place internal cache expiration time

--- a/src/Cache/BaseDataCache.php
+++ b/src/Cache/BaseDataCache.php
@@ -90,8 +90,6 @@ final class BaseDataCache implements DataCache
     {
         if ($ttl === null) {
             $ttl = 3600;
-        } elseif ($ttl <= 0) {
-            return $this->delete_data($key); // FreshRSS
         }
 
         // place internal cache expiration time

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -15,17 +15,15 @@ final class Utils
      * Negotiate the cache expiration time based on the HTTP response headers.
      * Return the cache duration time in number of seconds since the Unix Epoch, accounting for:
      * - `Cache-Control: max-age` minus `Age`, bounded by `$cache_duration_min` and `$cache_duration_max`
-     * - `Cache-Control: must-revalidate` will prevent `$cache_duration_min` from extending past the `max-age`
-     * - `Cache-Control: no-cache` will return the current time
-     * - `Cache-Control: no-store` will return `0`
+     * - `Cache-Control: must-revalidate` will set `$cache_duration` to `$cache_duration_min`
+     * - `Cache-Control: no-cache` will return `time() + $cache_duration_min`
+     * - `Cache-Control: no-store` will return `time() + $cache_duration_min - 3`
      * - `Expires` like `Cache-Control: max-age` but only if it is absent
      *
      * @param array<string,mixed> $http_headers HTTP headers of the response
      * @param int $cache_duration Desired cache duration in seconds, potentially overridden by HTTP response headers
-     * @param int $cache_duration_min Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
-     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache` and `Cache-Control: must-revalidate`
+     * @param int $cache_duration_min Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control` and `Expires`,
      * @param int $cache_duration_max Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
-     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
      * @return int The negotiated cache expiration time in seconds since the Unix Epoch
      *
      * FreshRSS
@@ -35,13 +33,13 @@ final class Utils
         $cache_control = $http_headers['cache-control'] ?? '';
         if ($cache_control !== '') {
             if (preg_match('/\bno-store\b/', $cache_control)) {
-                return 0;
+                return time() + $cache_duration_min - 3; // -3 to distinguish from no-cache if needed
             }
             if (preg_match('/\bno-cache\b/', $cache_control)) {
-                return time();
+                return time() + $cache_duration_min;
             }
             if (preg_match('/\bmust-revalidate\b/', $cache_control)) {
-                $cache_duration_min = 0;
+                $cache_duration = $cache_duration_min;
             }
             if (preg_match('/\bs-maxage=(\d+)\b/', $cache_control, $matches) || preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
                 $max_age = (int) $matches[1];
@@ -49,16 +47,16 @@ final class Utils
                 if (is_numeric($age)) {
                     $max_age -= (int) $age;
                 }
-                return time() + min(max($max_age, $cache_duration_min), $cache_duration_max);
+                return time() + min(max($max_age, $cache_duration), $cache_duration_max);
             }
         }
         $expires = $http_headers['expires'] ?? '';
         if ($expires !== '') {
             $expire_date = \SimplePie\Misc::parse_date($expires);
             if ($expire_date !== false) {
-                return min(max($expire_date, time() + $cache_duration_min), time() + $cache_duration_max);
+                return min(max($expire_date, time() + $cache_duration), time() + $cache_duration_max);
             }
         }
-        return time() + min(max($cache_duration, $cache_duration_min), $cache_duration_max);
+        return time() + $cache_duration;
     }
 }

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -43,7 +43,7 @@ final class Utils
             if (preg_match('/\bmust-revalidate\b/', $cache_control)) {
                 $cache_duration_min = 0;
             }
-            if (preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
+            if (preg_match('/\bs-maxage=(\d+)\b/', $cache_control, $matches) || preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
                 $max_age = (int) $matches[1];
                 $age = $http_headers['age'] ?? '';
                 if (is_numeric($age)) {

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -41,7 +41,7 @@ final class Utils
             if (preg_match('/\bmust-revalidate\b/', $cache_control)) {
                 $cache_duration = $cache_duration_min;
             }
-            if (preg_match('/\bs-maxage=(\d+)\b/', $cache_control, $matches) || preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
+            if (preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
                 $max_age = (int) $matches[1];
                 $age = $http_headers['age'] ?? '';
                 if (is_numeric($age)) {

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -21,12 +21,12 @@ final class Utils
      * - `Expires` like `Cache-Control: max-age` but only if it is absent
      *
      * @param array<string,mixed> $http_headers HTTP headers of the response
-     * @param int $cache_duration Desired cache duration in seconds, potentially overriden by HTTP response headers
+     * @param int $cache_duration Desired cache duration in seconds, potentially overridden by HTTP response headers
      * @param int $cache_duration_min Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
      * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache` and `Cache-Control: must-revalidate`
      * @param int $cache_duration_max Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
      * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
-     * @return int The negociated cache expiration time in seconds since the Unix Epoch
+     * @return int The negotiated cache expiration time in seconds since the Unix Epoch
      *
      * FreshRSS
      */

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -21,8 +21,8 @@ final class Utils
      */
     public static function get_http_max_age(array $http_headers): ?int
     {
-        $cache_control = $http_headers['cache-control'] ?? '';
-        if (is_string($cache_control) && $cache_control !== '' && preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
+        $cache_control = $http_headers['cache-control'] ?? null;
+        if (is_string($cache_control) && preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
             return (int) $matches[1];
         }
         return null;

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -11,6 +11,24 @@ namespace SimplePie\HTTP;
  */
 final class Utils
 {
+
+    /**
+     * Extracts `max-age` from the `Cache-Control` HTTP headers
+     *
+     * @param array<string,mixed> $http_headers HTTP headers of the response
+     * @return int|null The `max-age` value or `null` if not found
+     *
+     * FreshRSS
+     */
+    public static function get_http_max_age(array $http_headers): ?int
+    {
+        $cache_control = $http_headers['cache-control'] ?? '';
+        if (is_string($cache_control) && $cache_control !== '' && preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
+            return (int) $matches[1];
+        }
+        return null;
+    }
+
     /**
      * Negotiate the cache expiration time based on the HTTP response headers.
      * Return the cache duration time in number of seconds since the Unix Epoch, accounting for:

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -22,8 +22,10 @@ final class Utils
      *
      * @param array<string,mixed> $http_headers HTTP headers of the response
      * @param int $cache_duration Desired cache duration in seconds, potentially overriden by HTTP response headers
-     * @param int $cache_duration_min Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`
-     * @param int $cache_duration_max Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`
+     * @param int $cache_duration_min Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
+     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache` and `Cache-Control: must-revalidate`
+     * @param int $cache_duration_max Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
+     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
      * @return int The negociated cache expiration time in seconds since the Unix Epoch
      *
      * FreshRSS

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -6,7 +6,7 @@ namespace SimplePie\HTTP;
 
 /**
  * HTTP util functions
- *
+ * FreshRSS
  * @internal
  */
 final class Utils
@@ -14,18 +14,21 @@ final class Utils
     /**
      * Negotiate the cache expiration time based on the HTTP response headers.
      * Return the cache duration time in number of seconds since the Unix Epoch, accounting for:
-     * - `Cache-Control: max-age` minus `Age`, extendable by `$simplepie_cache_duration`
-     * - `Cache-Control: must-revalidate` will prevent `$simplepie_cache_duration` from extending past the `max-age`
+     * - `Cache-Control: max-age` minus `Age`, bounded by `$cache_duration_min` and `$cache_duration_max`
+     * - `Cache-Control: must-revalidate` will prevent `$cache_duration_min` from extending past the `max-age`
      * - `Cache-Control: no-cache` will return the current time
      * - `Cache-Control: no-store` will return `0`
-     * - `Expires` but only if `Cache-Control: max-age` is absent
+     * - `Expires` like `Cache-Control: max-age` but only if it is absent
      *
-     * @param int $simplepie_cache_duration Cache duration in seconds desired from SimplePie
      * @param array<string,mixed> $http_headers HTTP headers of the response
-     * @return int
+     * @param int $cache_duration Desired cache duration in seconds, potentially overriden by HTTP response headers
+     * @param int $cache_duration_min Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`
+     * @param int $cache_duration_max Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`
+     * @return int The negociated cache expiration time in seconds since the Unix Epoch
+     *
      * FreshRSS
      */
-    public static function negociate_cache_expiration_time(int $simplepie_cache_duration, array $http_headers): int
+    public static function negociate_cache_expiration_time(array $http_headers, int $cache_duration, int $cache_duration_min, int $cache_duration_max): int
     {
         $cache_control = $http_headers['cache-control'] ?? '';
         if ($cache_control !== '') {
@@ -33,10 +36,10 @@ final class Utils
                 return 0;
             }
             if (preg_match('/\bno-cache\b/', $cache_control)) {
-                return time() + 1; // +1 to account for inequalities
+                return time();
             }
             if (preg_match('/\bmust-revalidate\b/', $cache_control)) {
-                $simplepie_cache_duration = 0;
+                $cache_duration_min = 0;
             }
             if (preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
                 $max_age = (int) $matches[1];
@@ -44,16 +47,16 @@ final class Utils
                 if (is_numeric($age)) {
                     $max_age -= (int) $age;
                 }
-                return time() + $max_age + $simplepie_cache_duration + 1;
+                return time() + min(max($max_age, $cache_duration_min), $cache_duration_max);
             }
         }
         $expires = $http_headers['expires'] ?? '';
         if ($expires !== '') {
             $expire_date = \SimplePie\Misc::parse_date($expires);
             if ($expire_date !== false) {
-                return $expire_date + $simplepie_cache_duration + 1;
+                return min(max($expire_date, time() + $cache_duration_min), time() + $cache_duration_max);
             }
         }
-        return $simplepie_cache_duration + time();
+        return time() + min(max($cache_duration, $cache_duration_min), $cache_duration_max);
     }
 }

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -11,7 +11,6 @@ namespace SimplePie\HTTP;
  */
 final class Utils
 {
-
     /**
      * Extracts `max-age` from the `Cache-Control` HTTP headers
      *

--- a/src/HTTP/Utils.php
+++ b/src/HTTP/Utils.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimplePie\HTTP;
+
+/**
+ * HTTP util functions
+ *
+ * @internal
+ */
+final class Utils
+{
+    /**
+     * Negotiate the cache expiration time based on the HTTP response headers.
+     * Return the cache duration time in number of seconds since the Unix Epoch, accounting for:
+     * - `Cache-Control: max-age` minus `Age`, extendable by `$simplepie_cache_duration`
+     * - `Cache-Control: must-revalidate` will prevent `$simplepie_cache_duration` from extending past the `max-age`
+     * - `Cache-Control: no-cache` will return the current time
+     * - `Cache-Control: no-store` will return `0`
+     * - `Expires` but only if `Cache-Control: max-age` is absent
+     *
+     * @param int $simplepie_cache_duration Cache duration in seconds desired from SimplePie
+     * @param array<string,mixed> $http_headers HTTP headers of the response
+     * @return int
+     * FreshRSS
+     */
+    public static function negociate_cache_expiration_time(int $simplepie_cache_duration, array $http_headers): int
+    {
+        $cache_control = $http_headers['cache-control'] ?? '';
+        if ($cache_control !== '') {
+            if (preg_match('/\bno-store\b/', $cache_control)) {
+                return 0;
+            }
+            if (preg_match('/\bno-cache\b/', $cache_control)) {
+                return time() + 1; // +1 to account for inequalities
+            }
+            if (preg_match('/\bmust-revalidate\b/', $cache_control)) {
+                $simplepie_cache_duration = 0;
+            }
+            if (preg_match('/\bmax-age=(\d+)\b/', $cache_control, $matches)) {
+                $max_age = (int) $matches[1];
+                $age = $http_headers['age'] ?? '';
+                if (is_numeric($age)) {
+                    $max_age -= (int) $age;
+                }
+                return time() + $max_age + $simplepie_cache_duration + 1;
+            }
+        }
+        $expires = $http_headers['expires'] ?? '';
+        if ($expires !== '') {
+            $expire_date = \SimplePie\Misc::parse_date($expires);
+            if ($expire_date !== false) {
+                return $expire_date + $simplepie_cache_duration + 1;
+            }
+        }
+        return $simplepie_cache_duration + time();
+    }
+}

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -509,7 +509,7 @@ class SimplePie
     public $force_cache_fallback = false;
 
     /**
-     * @var int Cache duration (in seconds), but may be overriden by HTTP response headers (FreshRSS)
+     * @var int Cache duration (in seconds), but may be overridden by HTTP response headers (FreshRSS)
      * @see SimplePie::set_cache_duration()
      * @access private
      */
@@ -1009,7 +1009,7 @@ class SimplePie
      *
      * FreshRSS: The cache is (partially) HTTP compliant, with the following rules:
      *
-     * @param int $seconds The feed content cache duration, which may be overriden by HTTP response headers)
+     * @param int $seconds The feed content cache duration, which may be overridden by HTTP response headers)
      * @param int $min The minimun cache duration (default: 60s), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
      * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache` and `Cache-Control: must-revalidate`
      * @param int $max The maximum cache duration (default: 24h), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -516,7 +516,7 @@ class SimplePie
     public $cache_duration = 3600;
 
     /**
-     * @var int Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control` and `Expires`,
+     * @var int Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control` and `Expires`
      * @see SimplePie::set_cache_duration()
      * @access private
      * FreshRSS
@@ -524,7 +524,7 @@ class SimplePie
     public $cache_duration_min = 60;
 
     /**
-     * @var int Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control` and `Expires`,
+     * @var int Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control` and `Expires`
      * @see SimplePie::set_cache_duration()
      * @access private
      * FreshRSS
@@ -1008,8 +1008,8 @@ class SimplePie
      * FreshRSS: The cache is (partially) HTTP compliant, with the following rules:
      *
      * @param int $seconds The feed content cache duration, which may be overridden by HTTP response headers)
-     * @param int $min The minimun cache duration (default: 60s), overriding HTTP response headers `Cache-Control` and `Expires`,
-     * @param int $max The maximum cache duration (default: 24h), overriding HTTP response headers `Cache-Control` and `Expires`,
+     * @param int $min The minimum cache duration (default: 60s), overriding HTTP response headers `Cache-Control` and `Expires`
+     * @param int $max The maximum cache duration (default: 24h), overriding HTTP response headers `Cache-Control` and `Expires`
      * @return void
      */
     public function set_cache_duration(int $seconds = 3600, ?int $min = null, ?int $max = null)

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1851,7 +1851,7 @@ class SimplePie
                     $this->data['hash'] = $this->data['hash'] ?? $this->clean_hash($this->raw_data); // FreshRSS
 
                     // Cache the file if caching is enabled
-                    $this->data['cache_expiration_time'] = $this->cache_duration + time();
+                    $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->cache_duration, $this->data['headers'] ?? []);
 
                     if ($cache && !$cache->set_data($this->get_cache_filename($this->feed_url), $this->data, $this->cache_duration)) {
                         trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
@@ -1972,7 +1972,7 @@ class SimplePie
                             $this->status_code = 0;
 
                             if ($this->force_cache_fallback) {
-                                $this->data['cache_expiration_time'] = $this->cache_duration + time(); // FreshRSS
+                                $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->cache_duration, $this->data['headers'] ?? []); // FreshRSS
                                 $cache->set_data($cacheKey, $this->data, $this->cache_duration);
 
                                 return true;
@@ -1987,7 +1987,7 @@ class SimplePie
                             $this->raw_data = false;
                             if (isset($file)) { // FreshRSS
                                 // Update cache metadata
-                                $this->data['cache_expiration_time'] = $this->cache_duration + time();
+                                $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->cache_duration, $this->data['headers'] ?? []);
                                 $this->data['headers'] = array_map(function (array $values): string {
                                     return implode(',', $values);
                                 }, $file->get_headers());
@@ -2001,7 +2001,7 @@ class SimplePie
                         $hash = $this->clean_hash($file->get_body_content());
                         if (($this->data['hash'] ?? null) === $hash) {
                             // Update cache metadata
-                            $this->data['cache_expiration_time'] = $this->cache_duration + time();
+                            $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->cache_duration, $this->data['headers'] ?? []);
                             $this->data['headers'] = array_map(function (array $values): string {
                                 return implode(',', $values);
                             }, $file->get_headers());
@@ -2138,7 +2138,7 @@ class SimplePie
                         'url' => $this->feed_url,
                         'feed_url' => $file->get_final_requested_uri(),
                         'build' => Misc::get_build(),
-                        'cache_expiration_time' => $this->cache_duration + time(),
+                        'cache_expiration_time' => \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->cache_duration, $this->data['headers'] ?? []), // FreshRSS
                         'cache_version' => self::CACHE_VERSION, // FreshRSS
                         'hash' => empty($hash) ? $this->clean_hash($file->get_body_content()) : $hash, // FreshRSS
                     ];

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2179,7 +2179,7 @@ class SimplePie
                         'hash' => empty($hash) ? $this->clean_hash($file->get_body_content()) : $hash, // FreshRSS
                     ];
 
-                    if (!$cache->set_data($cacheKey, $this->data, $this->cache_duration)) { // FreshRSS
+                    if (!$cache->set_data($cacheKey, $this->data, $this->cache_duration)) {
                         trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
                     }
                 }

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -516,8 +516,8 @@ class SimplePie
     public $cache_duration = 3600;
 
     /**
-     * @var int Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`.
-     * But no effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
+     * @var int Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
+     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache` and `Cache-Control: must-revalidate`
      * @see SimplePie::set_cache_duration()
      * @access private
      * FreshRSS
@@ -525,8 +525,8 @@ class SimplePie
     public $cache_duration_min = 60;
 
     /**
-     * @var int Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`.
-     * But no effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
+     * @var int Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
+     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
      * @see SimplePie::set_cache_duration()
      * @access private
      * FreshRSS
@@ -1007,12 +1007,13 @@ class SimplePie
      * Set the length of time (in seconds) that the contents of a feed will be
      * cached
      *
-     * FreshRSS: Note that the cache is (partially) HTTP compliant,
-     * so minimum and maximum parameters have no effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
+     * FreshRSS: The cache is (partially) HTTP compliant, with the following rules:
      *
      * @param int $seconds The feed content cache duration, which may be overriden by HTTP response headers)
-     * @param int $min The minimun cache duration (default: 60s), overriding HTTP response headers `Cache-Control: max-age` and `Expires`
-     * @param int $max The maximum cache duration (default: 24h), overriding HTTP response headers `Cache-Control: max-age` and `Expires`
+     * @param int $min The minimun cache duration (default: 60s), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
+     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache` and `Cache-Control: must-revalidate`
+     * @param int $max The maximum cache duration (default: 24h), overriding HTTP response headers `Cache-Control: max-age` and `Expires`,
+     * but without effect on `Cache-Control: no-store` and `Cache-Control: no-cache`
      * @return void
      */
     public function set_cache_duration(int $seconds = 3600, ?int $min = null, ?int $max = null)

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2021,7 +2021,7 @@ class SimplePie
                                 // Update cache metadata
                                 $this->data['headers'] = array_map(function (array $values): string {
                                     return implode(',', $values);
-                                }, $file->get_headers()); // FreshRSS
+                                }, $file->get_headers());
                                 $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->data['headers'] ?? [], $this->cache_duration, $this->cache_duration_min, $this->cache_duration_max);
                             }
                             if (!$cache->set_data($cacheKey, $this->data, $this->cache_duration)) { // FreshRSS
@@ -2039,7 +2039,7 @@ class SimplePie
                                 return implode(',', $values);
                             }, $file->get_headers());
                             $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->data['headers'] ?? [], $this->cache_duration, $this->cache_duration_min, $this->cache_duration_max);
-                            if (!$cache->set_data($cacheKey, $this->data, $this->cache_duration)) { // FreshRSS
+                            if (!$cache->set_data($cacheKey, $this->data, $this->cache_duration)) {
                                 trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
                             }
 

--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -2019,10 +2019,10 @@ class SimplePie
                             $this->raw_data = false;
                             if (isset($file)) { // FreshRSS
                                 // Update cache metadata
-                                $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->data['headers'] ?? [], $this->cache_duration, $this->cache_duration_min, $this->cache_duration_max);
                                 $this->data['headers'] = array_map(function (array $values): string {
                                     return implode(',', $values);
-                                }, $file->get_headers());
+                                }, $file->get_headers()); // FreshRSS
+                                $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->data['headers'] ?? [], $this->cache_duration, $this->cache_duration_min, $this->cache_duration_max);
                             }
                             if (!$cache->set_data($cacheKey, $this->data, $this->cache_duration)) { // FreshRSS
                                 trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
@@ -2035,10 +2035,10 @@ class SimplePie
                         $hash = $this->clean_hash($file->get_body_content());
                         if (($this->data['hash'] ?? null) === $hash) {
                             // Update cache metadata
-                            $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->data['headers'] ?? [], $this->cache_duration, $this->cache_duration_min, $this->cache_duration_max);
                             $this->data['headers'] = array_map(function (array $values): string {
                                 return implode(',', $values);
                             }, $file->get_headers());
+                            $this->data['cache_expiration_time'] = \SimplePie\HTTP\Utils::negociate_cache_expiration_time($this->data['headers'] ?? [], $this->cache_duration, $this->cache_duration_min, $this->cache_duration_max);
                             if (!$cache->set_data($cacheKey, $this->data, $this->cache_duration)) { // FreshRSS
                                 trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
                             }


### PR DESCRIPTION
Negotiate the cache expiration time based on the HTTP response headers.
Return the cache duration time in number of seconds since the Unix Epoch, accounting for:
- `Cache-Control: max-age` minus `Age`, bounded by `$cache_duration_min` and `$cache_duration_max`
- `Cache-Control: must-revalidate` will set `$cache_duration` to `$cache_duration_min`
- `Cache-Control: no-cache` will return `time() + $cache_duration_min`
- `Cache-Control: no-store` will return `time() + $cache_duration_min - 3` (to distinguish from no-cache if needed)
- `Expires` like `Cache-Control: max-age` but only if it is absent

Parameters:
* `$cache_duration` Desired cache duration in seconds, potentially overridden by HTTP response headers
* `$cache_duration_min` Minimal cache duration (in seconds), overriding HTTP response headers `Cache-Control` and `Expires`
* `$cache_duration_max` Maximal cache duration (in seconds), overriding HTTP response headers `Cache-Control` and `Expires`
