### PR TITLE
Fix support for feeds with XML preample + DTD, entities

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -111,11 +111,18 @@ class Parser implements RegistryAware
             $declaration = $this->registry->create(DeclarationParser::class, [substr($data, 5, $pos - 5)]);
             if ($declaration->parse()) {
                 $data = substr($data, $pos + 2);
-                $data = '<?xml version="' . $declaration->version . '" encoding="' . $encoding . '" standalone="' . (($declaration->standalone) ? 'yes' : 'no') . '"?>' ."\n". $this->declare_html_entities() . $data;
+                $data = preg_replace('/^\\s*<!DOCTYPE\\s[^>\\[\\]]*>\s*/', '', $data);  // Strip DOCTYPE except if containing an [internal subset]
+                $data = '<?xml version="' . $declaration->version . '" encoding="' . $encoding . '" standalone="' . (($declaration->standalone) ? 'yes' : 'no') . '"?>' . "\n" .
+                    (preg_match('/^\\s*<!DOCTYPE\\s/', $data) ? '' : $this->declare_html_entities()) .  // Declare HTML entities only if no remaining DOCTYPE
+                    $data;
             } else {
                 $this->error_string = 'SimplePie bug! Please report this!';
                 return false;
             }
+        } else {
+            $data = preg_replace('/^\\s*<!DOCTYPE\\s[^>\\[\\]]*>\s*/', '', $data);   // Strip DOCTYPE except if containing an [internal subset]
+            $data = (preg_match('/^\\s*<!DOCTYPE\\s/', $data) ? '' : $this->declare_html_entities()) .  // Declare HTML entities only if no remaining DOCTYPE
+                $data;
         }
 
         $return = true;

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -4312,6 +4312,93 @@ EOT
                 ,
                 'Item Title',
             ],
+            'Test RSS 0.91 XML and DTD' => [
+<<<XML
+<?xml version="1.0"?>
+<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN" "http://www.rssboard.org/rss-0.91.dtd">
+<rss version="0.91">
+	<channel>
+		<item>
+			<title>Item Title</title>
+		</item>
+	</channel>
+</rss>
+XML
+                ,
+                'Item Title',
+            ],
+            'Test RSS 0.91 XML and DTD and external HTML entity' => [
+<<<XML
+<?xml version="1.0"?>
+<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN" "http://www.rssboard.org/rss-0.91.dtd">
+<rss version="0.91">
+	<channel>
+		<item>
+			<title>caf&eacute;</title>
+		</item>
+	</channel>
+</rss>
+XML
+                ,
+                'café',
+            ],
+            'Test RSS 0.91 DTD and external HTML entity' => [
+<<<XML
+<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN" "http://www.rssboard.org/rss-0.91.dtd">
+<rss version="0.91">
+	<channel>
+		<item>
+			<title>caf&eacute;</title>
+		</item>
+	</channel>
+</rss>
+XML
+                ,
+                'café',
+            ],
+            'Test RSS 0.91 internal DTD with internal entity' => [
+<<<XML
+<!DOCTYPE rss [
+	<!ENTITY helloworld "Hello World!">
+]>
+<rss version="0.91">
+	<channel>
+		<item>
+			<title>&helloworld;</title>
+		</item>
+	</channel>
+</rss>
+XML
+                ,
+                'Hello World!',
+            ],
+            'Test RSS 0.91 XML and undeclared HTML entity (invalid)' => [
+<<<XML
+<?xml version="1.0"?>
+<rss version="0.91">
+	<channel>
+		<item>
+			<title>caf&eacute;</title>
+		</item>
+	</channel>
+</rss>
+XML
+                ,
+                'café',
+            ],
+            'Test RSS 0.91 with undeclared HTML entity (invalid)' => [
+<<<XML
+<rss version="0.91">
+	<channel>
+		<item>
+			<title>caf&eacute;</title>
+		</item>
+	</channel>
+</rss>
+XML
+                ,
+                'café',
+            ],
             'Test RSS 0.91-Userland Atom 0.3 Title' => [
 <<<EOT
 <rss version="0.91" xmlns:a="http://purl.org/atom/ns#">


### PR DESCRIPTION
Alternative of https://github.com/simplepie/simplepie/pull/914 with support for XML feeds using HTML entities

Simple feeds with XML preample + DTD are crashing (see example in test) due to regression from https://github.com/simplepie/simplepie/commit/162a3d3878b755c93820ea672d83b3f6ac866f8f Its implementation is buggy, as it creates a second DOCTYPE declaration even when there is an existing one, which is completely invalid.

Example of feed: https://blog.plover.com/index.rss
Downstream Issue: https://github.com/FreshRSS/FreshRSS/issues/7514

Note that the culprit feature *added support for html entities in xml* seems to come from a misunderstanding of https://www.rssboard.org/rss-encoding-examples
HTML entities are only allowed in XML when there is a DTD declaring them. SimplePie is even allowing Atom documents with undeclared HTML entities - which I am not sure is on purpose.

Downstream issue: https://github.com/FreshRSS/FreshRSS/issues/7687