### PR TITLE
Fix feeds encoded in UTF-16LE

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -156,7 +156,7 @@ class File implements Response
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);
-                        $this->body = trim($parser->body);
+                        $this->body = trim($parser->body, " \n\r\t\v"); // Do not trim \x00 to avoid breaking BOM or multibyte characters
                         $this->status_code = $parser->status_code;
                         if ((in_array($this->status_code, [300, 301, 302, 303, 307]) || $this->status_code > 307 && $this->status_code < 400) && ($locationHeader = $this->get_header_line('location')) !== '' && $this->redirects < $redirects) {
                             $this->redirects++;


### PR DESCRIPTION
Example of valid feed not working in SimplePie: https://haveibeenpwned.com/feed/breaches/
Regression due to https://github.com/simplepie/simplepie/pull/445
The final character `>` of a feed is encoded as `3E00` in UTF-16LE, so calling `trim()` was removing the `\x00`, breaking the multibyte encoding and making the feed invalid.
Downstream issue https://github.com/FreshRSS/FreshRSS/issues/7690
Upstream PR https://github.com/simplepie/simplepie/pull/916
