### PR TITLE
Fix regex backtrack limit in clean_hash()

### DIFF
--- a/src/SimplePie.php
+++ b/src/SimplePie.php
@@ -1695,7 +1695,7 @@ class SimplePie
                         [
                             '#<(lastBuildDate|pubDate|updated|feedDate|dc:date|slash:comments)>[^<]+</\\1>#',
                             '#<(media:starRating|media:statistics) [^/<>]+/>#',
-                            '#<!--.+?-->#s',
+                            '#<!--.{,8192}?(-->|(?=]]>))#s', // XML comments up to a max length and stops at apparent end of CDATA section
                         ],
                         '',
                         $stream_data


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/7807
We had a risk of hitting `Backtrack limit was exhausted` in case of open XML comment `<!--` not closed and followed by a very long document.
Fixed by:
* Limiting the max length of the comment
* Stopping at an apparent end of CDATA section `]]>` as it is likely an error

It does not matter much if there are rare cases when the regex does not work perfectly, as it is only used for a cache hint.
