### PR TITLE
Merge fix http trailer headers

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -133,7 +133,7 @@ class File implements Response
                 curl_setopt($fp, CURLOPT_USERAGENT, $useragent);
                 curl_setopt($fp, CURLOPT_HTTPHEADER, $headers2);
                 $responseHeaders = '';
-                curl_setopt($fp, CURLOPT_HEADERFUNCTION, function (\CurlHandle $ch, string $header) use (&$responseHeaders) {
+                curl_setopt($fp, CURLOPT_HEADERFUNCTION, function ($ch, string $header) use (&$responseHeaders) {
                     if (trim($header) !== '') { // Skip e.g. separation with trailer headers
                         $responseHeaders .= $header;
                     }

--- a/src/File.php
+++ b/src/File.php
@@ -171,7 +171,7 @@ class File implements Response
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);
-                        $this->body = $responseBody;
+                        $this->body = $responseBody === false ? null : $responseBody;
                         if ((in_array($this->status_code, [300, 301, 302, 303, 307]) || $this->status_code > 307 && $this->status_code < 400) && ($locationHeader = $this->get_header_line('location')) !== '' && $this->redirects < $redirects) {
                             $this->redirects++;
                             $location = \SimplePie\Misc::absolutize_url($locationHeader, $url);


### PR DESCRIPTION
fix https://github.com/simplepie/simplepie/issues/942

Some feeds are not parsed correctly due to wrong handling of [HTTP trailer headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Trailer) such as [Server-Timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing).

Example of feed:
https://www.caranddriver.com/rss/all.xml
(Note that the bug may or may not exhibit itself depending on the cURL and PHP versions)

Downstream discussion:
* https://github.com/FreshRSS/FreshRSS/discussions/7981
* https://github.com/FreshRSS/FreshRSS/pull/7983

SimplePie tries to XML parse something like `</rss>server-timing: rtt; dur=6.131, retrans; dur=0, trailer-timestamp; dur=1758222994925` which obviously fails.

In the case of normal HTTP transfer (not chunked), we need to use content-length to know where the body stops, but content-length is wrong if any compression was used.
So I believe we should let cURL perform the separation of HTTP headers and body instead of using the SimplePie parser.
