### PR TITLE
Merge branch: Fix merge HTTP headers with cURL options

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -110,7 +110,7 @@ class File implements Response
             }
             if (!$force_fsockopen && function_exists('curl_exec')) {
                 $this->method = \SimplePie\SimplePie::FILE_SOURCE_REMOTE | \SimplePie\SimplePie::FILE_SOURCE_CURL;
-                 $fp = curl_init();
+                $fp = curl_init();
                 if (is_array($curl_options[CURLOPT_HTTPHEADER] ?? null)) {
                     // Save the original casing of HTTP headers
                     $headers_keys = array_combine(array_map('strtolower', array_keys($headers)), array_keys($headers));

--- a/src/File.php
+++ b/src/File.php
@@ -113,7 +113,7 @@ class File implements Response
                 $fp = curl_init();
                 if (is_array($curl_options[CURLOPT_HTTPHEADER] ?? null)) {
                     // Save the original casing of HTTP headers
-                    $headers_keys = array_combine(array_map('strtolower', array_keys($headers)), array_keys($headers));
+                    $headers_keys = array_combine(array_map('strtolower', array_keys($headers)), array_keys($headers)) ?: [];
                     // Merge HTTP headers case-insensitively from cURL options with the ones from the dedicated parameter
                     $headers = array_change_key_case($headers, CASE_LOWER);
                     foreach ($curl_options[CURLOPT_HTTPHEADER] as $header) {


### PR DESCRIPTION
HTTP headers were not merged properly, and were also not accounting for possible casing differences.
Follow-up of https://github.com/simplepie/simplepie/pull/912
It was for instance not possible to override the `Accept` header from the cURL options.
The existing code could not work properly because we were merging arrays of strings and not arrays of key-values, leading to strange duplicates.

Downstream:
* https://github.com/FreshRSS/FreshRSS/pull/8246

Upstream:
* https://github.com/simplepie/simplepie/pull/956
