### PR TITLE
Merge: Fix Undefined array key "" in get_thumbnail()

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -354,7 +354,7 @@ class Item implements RegistryAware
     {
         if (!isset($this->data['thumbnail'])) {
             if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'thumbnail')) {
-                $thumbnail = $return[0]['attribs'][''];
+                $thumbnail = $return[0]['attribs'][''] ?? [];
                 if (empty($thumbnail['url'])) {
                     $this->data['thumbnail'] = null;
                 } else {

--- a/tests/Unit/ItemTest.php
+++ b/tests/Unit/ItemTest.php
@@ -5035,4 +5035,33 @@ XML
             'http://example.net/link?a=%22b%22&amp;c=%3Cd%3E',
         ];
     }
+
+    public function test_get_thumbnail_returns_null_when_attributes_are_missing(): void
+    {
+        $feed = new SimplePie();
+        $feed->set_raw_data(
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test thumbnail without attributes</title>
+                    <description>Test thumbnail without attributes</description>
+                    <link>http://example.org/tests/</link>
+                    <item>
+                        <title>Test thumbnail without attributes 1.1</title>
+                        <description>Test thumbnail without attributes 1.1</description>
+                        <guid>http://example.net/tests/#1.1</guid>
+                        <link>http://example.net/tests/#1.1</link>
+                        <media:thumbnail />
+                    </item>
+                </channel>
+            </rss>
+XML
+        );
+        $feed->enable_cache(false);
+        $feed->init();
+
+        $item = $feed->get_item(0);
+        self::assertInstanceOf(Item::class, $item);
+        self::assertNull($item->get_thumbnail());
+    }
 }


### PR DESCRIPTION
https://github.com/simplepie/simplepie/pull/970
Downstream:
fix https://github.com/FreshRSS/FreshRSS/issues/8614

Solve warning in the case of `<media:thumbnail />`
