### PR TITLE
Parser: handle HTTP 103 Early Hints

### DIFF
--- a/src/HTTP/Parser.php
+++ b/src/HTTP/Parser.php
@@ -63,6 +63,8 @@ class Parser
 
     private const STATE_BODY = 'body';
 
+    private const STATE_BODY_OR_STATUS = 'body_or_status';
+
     private const STATE_NAME = 'name';
 
     private const STATE_VALUE = 'value';
@@ -148,7 +150,7 @@ class Parser
             $this->$state();
         }
         $this->data = '';
-        if ($this->state === self::STATE_EMIT || $this->state === self::STATE_BODY) {
+        if ($this->state === self::STATE_EMIT || ($this->state === self::STATE_BODY_OR_STATUS && $this->status_code !== 0 && $this->status_code !== 103)) {
             return true;
         }
 
@@ -265,6 +267,26 @@ class Parser
     }
 
     /**
+     * Move to the response following HTTP 103 Early Hints.
+     *
+     * A final response without a body leaves this state at end of input.
+     *
+     * @return void
+     */
+    protected function body_or_status()
+    {
+        if ($this->status_code === 103) {
+            $this->http_version = 0.0;
+            $this->status_code = 0;
+            $this->reason = '';
+            $this->headers = [];
+            $this->state = self::STATE_HTTP_VERSION;
+        } else {
+            $this->state = self::STATE_BODY;
+        }
+    }
+
+    /**
      * Deal with a new line, shifting data around as needed
      * @return void
      */
@@ -284,10 +306,10 @@ class Parser
         $this->value = '';
         if (substr($this->data[$this->position], 0, 2) === "\x0D\x0A") {
             $this->position += 2;
-            $this->state = self::STATE_BODY;
+            $this->state = self::STATE_BODY_OR_STATUS;
         } elseif ($this->data[$this->position] === "\x0A") {
             $this->position++;
-            $this->state = self::STATE_BODY;
+            $this->state = self::STATE_BODY_OR_STATUS;
         } else {
             $this->state = self::STATE_NAME;
         }

--- a/tests/Unit/HTTP/ParserTest.php
+++ b/tests/Unit/HTTP/ParserTest.php
@@ -165,4 +165,43 @@ class ParserTest extends TestCase
             'content-security-policy' => ["default-src 'self' http://example.com", 'script-src http://example.com/'],
         ], $parser->headers);
     }
+
+    public function testEarlyHintsAreSkipped(): void
+    {
+        $earlyHints = "HTTP/1.1 103 Early Hints\r\nLink: </style.css>; rel=preload; as=style\r\n\r\n";
+        $response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nfeed body";
+
+        $parser = new Parser($earlyHints . $response, true);
+
+        self::assertTrue($parser->parse());
+        self::assertSame(1.1, $parser->http_version);
+        self::assertSame(200, $parser->status_code);
+        self::assertSame('OK', $parser->reason);
+        self::assertSame(['content-type' => ['text/plain']], $parser->headers);
+        self::assertSame('feed body', $parser->body);
+    }
+
+    public function testMultipleEarlyHintsAreSkipped(): void
+    {
+        $earlyHints = "HTTP/1.1 103 Early Hints\r\nLink: </style.css>; rel=preload; as=style\r\n\r\n";
+        $response = "HTTP/1.1 308 Permanent Redirect\r\nLocation: https://example.com/feed\r\n\r\n";
+
+        $parser = new Parser($earlyHints . $earlyHints . $response, true);
+
+        self::assertTrue($parser->parse());
+        self::assertSame(308, $parser->status_code);
+        self::assertSame('Permanent Redirect', $parser->reason);
+        self::assertSame(['location' => ['https://example.com/feed']], $parser->headers);
+        self::assertSame('', $parser->body);
+    }
+
+    public function testIncompleteEarlyHintsResponseFails(): void
+    {
+        $parser = new Parser("HTTP/1.1 103 Early Hints\r\nLink: </style.css>; rel=preload; as=style\r\n\r\n", true);
+
+        self::assertFalse($parser->parse());
+        self::assertSame(0, $parser->status_code);
+        self::assertSame([], $parser->headers);
+        self::assertSame('', $parser->body);
+    }
 }


### PR DESCRIPTION
## Summary

- Skip HTTP 103 Early Hints header blocks and parse the following final response.
- Keep bodyless final responses, such as HTTP 308 redirects, valid.
- Reject a response stream that ends after an interim 103 response.
- Add focused parser coverage for these cases.

## Why

cURL can expose HTTP 103 headers before the final feed response. Previously the parser treated the 103 headers as the response and the actual status line as body data.

References FreshRSS/FreshRSS#7408.

## Testing

- `phpunit --no-configuration --bootstrap autoloader.php tests/Unit/HTTP/ParserTest.php` (25 tests, 129 assertions)
- PHP syntax checks for the changed source and test files
