### PR TITLE
Item::get_enclosures(): option to skip media:group alternative representations

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -932,9 +932,11 @@ class Item implements RegistryAware
      * @since Beta 2
      * @todo Add support for end-user defined sorting of enclosures by type/handler (so we can prefer the faster-loading FLV over MP4).
      * @todo If an element exists at a level, but its value is empty, we should fall back to the value from the parent (if it exists).
+     * @param bool $excludeMediaGroupAlternatives When true, only one `<media:content>` is kept per `<media:group>`
+     *   (the one marked `isDefault="true"`, or the first one), skipping the redundant alternative representations.
      * @return \SimplePie\Enclosure[]|null List of \SimplePie\Enclosure items
      */
-    public function get_enclosures()
+    public function get_enclosures(bool $excludeMediaGroupAlternatives = false)
     {
         if (!isset($this->data['enclosures'])) {
             $this->data['enclosures'] = [];
@@ -2294,11 +2296,70 @@ class Item implements RegistryAware
 
             $this->data['enclosures'] = array_values(array_unique($this->data['enclosures']));
         }
-        if (!empty($this->data['enclosures'])) {
-            return $this->data['enclosures'];
+
+        $enclosures = $this->data['enclosures'];
+        if ($excludeMediaGroupAlternatives && $enclosures !== []) {
+            $alternativeUrls = $this->get_media_group_alternative_urls();
+            if ($alternativeUrls !== []) {
+                $enclosures = array_values(array_filter(
+                    $enclosures,
+                    static function (\SimplePie\Enclosure $enclosure) use ($alternativeUrls): bool {
+                        return empty($alternativeUrls[$enclosure->get_link() ?? '']);
+                    }
+                ));
+            }
+        }
+        if (!empty($enclosures)) {
+            return $enclosures;
         }
 
         return null;
+    }
+
+    /**
+     * List the URLs of the redundant `<media:content>` alternatives inside `<media:group>` elements.
+     *
+     * A `<media:group>` gathers different representations of the same content (e.g. several video
+     * resolutions), so only one element per group should normally be shown: the one marked with
+     * `isDefault="true"`, or the first one otherwise.
+     *
+     * @link https://www.rssboard.org/media-rss#media-group
+     * @return array<string, true> URLs (as keys) of the media alternatives that should be skipped
+     */
+    private function get_media_group_alternative_urls(): array
+    {
+        $alternativeUrls = [];
+        foreach ((array) $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'group') as $group) {
+            $contents = $group['child'][\SimplePie\SimplePie::NAMESPACE_MEDIARSS]['content'] ?? null;
+            if (!is_array($contents) || count($contents) < 2) {
+                continue;
+            }
+            $urls = [];
+            $defaultUrl = null;
+            foreach ($contents as $content) {
+                if (!isset($content['attribs']['']['url'])) {
+                    continue;
+                }
+                // Same URL processing as when building the enclosures above, so the URLs can be compared
+                $url = $this->sanitize($content['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($content));
+                if ($url === '') {
+                    continue;
+                }
+                $urls[] = $url;
+                if ($defaultUrl === null && ($content['attribs']['']['isDefault'] ?? '') === 'true') {
+                    $defaultUrl = $url;
+                }
+            }
+            if ($defaultUrl === null) {
+                $defaultUrl = $urls[0] ?? '';
+            }
+            foreach ($urls as $url) {
+                if ($url !== $defaultUrl) {
+                    $alternativeUrls[$url] = true;
+                }
+            }
+        }
+        return $alternativeUrls;
     }
 
     /**

--- a/tests/Unit/EnclosureTest.php
+++ b/tests/Unit/EnclosureTest.php
@@ -192,6 +192,123 @@ XML
     }
 
     /**
+     * @dataProvider getEnclosuresMediaGroupAlternativesProvider
+     * @param string[] $expectedAllUrls
+     * @param string[] $expectedFilteredUrls
+     */
+    public function test_get_enclosures_exclude_media_group_alternatives(string $data, array $expectedAllUrls, array $expectedFilteredUrls): void
+    {
+        $feed = new SimplePie();
+        $feed->set_raw_data($data);
+        $feed->enable_cache(false);
+        $feed->init();
+
+        $item = $feed->get_item(0);
+        self::assertInstanceOf(Item::class, $item);
+
+        $getUrls = static function (?array $enclosures): array {
+            return array_map(static function (Enclosure $enclosure): ?string {
+                return $enclosure->get_link();
+            }, $enclosures ?? []);
+        };
+
+        self::assertSame($expectedAllUrls, $getUrls($item->get_enclosures()));
+        self::assertSame($expectedFilteredUrls, $getUrls($item->get_enclosures(true)));
+    }
+
+    /**
+     * @return iterable<array{string, string[], string[]}>
+     */
+    public static function getEnclosuresMediaGroupAlternativesProvider(): iterable
+    {
+        yield 'Test media:group keeps only the isDefault media:content' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test media group isDefault</title>
+                    <link>http://example.net/tests/</link>
+                    <item>
+                        <title>Test media group isDefault 1</title>
+                        <link>http://example.net/tests/#1.1</link>
+                        <media:group>
+                            <media:content url="http://example.net/videos/1-480.mp4" type="video/mp4" width="854" height="480" />
+                            <media:content url="http://example.net/videos/1-1080.mp4" type="video/mp4" width="1920" height="1080" isDefault="true" />
+                            <media:content url="http://example.net/videos/1-720.mp4" type="video/mp4" width="1280" height="720" />
+                        </media:group>
+                    </item>
+                </channel>
+            </rss>
+XML
+            ,
+            [
+                'http://example.net/videos/1-480.mp4',
+                'http://example.net/videos/1-1080.mp4',
+                'http://example.net/videos/1-720.mp4',
+            ],
+            [
+                'http://example.net/videos/1-1080.mp4',
+            ],
+        ];
+
+        yield 'Test media:group keeps the first media:content without isDefault' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test media group first</title>
+                    <link>http://example.net/tests/</link>
+                    <item>
+                        <title>Test media group first 1</title>
+                        <link>http://example.net/tests/#2.1</link>
+                        <media:group>
+                            <media:content url="http://example.net/videos/2-1080.mp4" type="video/mp4" width="1920" height="1080" />
+                            <media:content url="http://example.net/videos/2-720.mp4" type="video/mp4" width="1280" height="720" />
+                        </media:group>
+                    </item>
+                </channel>
+            </rss>
+XML
+            ,
+            [
+                'http://example.net/videos/2-1080.mp4',
+                'http://example.net/videos/2-720.mp4',
+            ],
+            [
+                'http://example.net/videos/2-1080.mp4',
+            ],
+        ];
+
+        yield 'Test media:group with relative URLs and other enclosures kept' => [
+            <<<XML
+            <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+                <channel>
+                    <title>Test media group relative</title>
+                    <link>http://example.net/tests/</link>
+                    <item>
+                        <title>Test media group relative 1</title>
+                        <link>http://example.net/tests/#3.1</link>
+                        <enclosure url="http://example.net/audio/3.mp3" type="audio/mpeg" />
+                        <media:group>
+                            <media:content url="/videos/3-720.mp4" type="video/mp4" width="1280" height="720" />
+                            <media:content url="/videos/3-480.mp4" type="video/mp4" width="854" height="480" />
+                        </media:group>
+                    </item>
+                </channel>
+            </rss>
+XML
+            ,
+            [
+                'http://example.net/videos/3-720.mp4',
+                'http://example.net/videos/3-480.mp4',
+                'http://example.net/audio/3.mp3',
+            ],
+            [
+                'http://example.net/videos/3-720.mp4',
+                'http://example.net/audio/3.mp3',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider getEnclosureIntAttributesProvider
      */
     public function test_enclosure_int_attributes(string $data, ?int $expectedDuration, ?int $expectedChannels, ?int $expectedLength): void


### PR DESCRIPTION
As requested by @Alkarex in FreshRSS/FreshRSS#9009, this ports the `src/Item.php` change from that PR to this repo. A `<media:group>` gathers alternative representations of the same content (e.g. several resolutions of one video), which currently yields one enclosure per representation.

`get_enclosures()` gains an optional `bool $excludeMediaGroupAlternatives = false` parameter; when true, a private helper keeps only one `<media:content>` per `<media:group>` - the one marked `isDefault="true"`, or the first - comparing URLs after the same `sanitize()`/`get_own_base()` processing used when building enclosures. Default is false, so behaviour is unchanged. Compared with the FreshRSS PR, the only edits are PHP 7.2 syntax downgrades (no arrow function, no `??=`, no trailing call comma) to match this repo's >=7.2 support. Includes a regression test in `tests/Unit/EnclosureTest.php` (fails without the `Item.php` change); `php-cs-fixer` and `phpstan` pass.

Written with the assistance of an AI tool (Claude), reviewed and tested by me.
